### PR TITLE
use /tmp in hardcoded-vars.yml instead of tmp to avoid errors

### DIFF
--- a/hardcoded-vars.yml
+++ b/hardcoded-vars.yml
@@ -1,4 +1,4 @@
 ---
 osbs_environment: {}
-osbs_openshift_home: tmp
+osbs_openshift_home: /tmp
 osbs_secret_remote_dir: "{{ osbs_openshift_home }}"


### PR DESCRIPTION
Signed-off-by: Adam Miller maxamillion@fedoraproject.org
